### PR TITLE
chore: bump packages to latest

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,23 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git mv:*)",
+      "Bash(git diff:*)",
+      "Bash(xargs -I{} sh -c 'echo \"\"=== {} ===\"\" && git diff HEAD~5 -- {} | grep -E \"\"^\\\\+.*///\"\" | head -5')",
+      "Bash(git ls-tree:*)",
+      "Bash(while read f)",
+      "Bash(do echo \"=== $f ===\")",
+      "Bash(done)",
+      "Bash(git checkout:*)",
+      "Bash(move:*)",
+      "Bash(nuget list:*)",
+      "Bash(dotnet nuget:*)",
+      "Bash(cat:*)",
+      "Bash(curl:*)",
+      "Bash(dotnet clean:*)",
+      "Bash(taskkill:*)",
+      "Bash(git stash:*)",
+      "Bash(grep:*)"
+    ]
+  }
+}

--- a/src/NosCore.Networking/NosCore.Networking.csproj
+++ b/src/NosCore.Networking/NosCore.Networking.csproj
@@ -25,13 +25,13 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="SuperSocket.Server" Version="2.0.2" />
-		<PackageReference Include="SuperSocket.ProtoBase" Version="2.0.2" />
-		<PackageReference Include="NodaTime" Version="3.2.0" />
+		<PackageReference Include="SuperSocket.Server" Version="2.1.0" />
+		<PackageReference Include="SuperSocket.ProtoBase" Version="2.1.0" />
+		<PackageReference Include="NodaTime" Version="3.3.1" />
 		<PackageReference Include="NosCore.Packets" Version="15.0.0" />
-		<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.14.0" />
-		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />
-		<PackageReference Include="Serilog" Version="4.3.0" />
+		<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.17.0" />
+		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
+		<PackageReference Include="Serilog" Version="4.3.1" />
 		<PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
 	</ItemGroup>
 

--- a/test/NosCore.Networking.Tests/NosCore.Networking.Tests.csproj
+++ b/test/NosCore.Networking.Tests/NosCore.Networking.Tests.csproj
@@ -20,18 +20,18 @@
 
 	<ItemGroup>
 		<PackageReference Include="ApprovalTests" Version="7.0.0" />
-		<PackageReference Include="coverlet.collector" Version="6.0.4">
+		<PackageReference Include="coverlet.collector" Version="10.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
-		<PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
-		<PackageReference Include="NodaTime.Testing" Version="3.2.0" />
-		<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.14.0" />
-		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
+		<PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
+		<PackageReference Include="NodaTime.Testing" Version="3.3.1" />
+		<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.17.0" />
+		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Bulk package update. Supersedes all open Dependabot PRs.

Note: `NosCore.Packets` left at its current version — that'll be picked up once the packages PR publishes a new NuGet release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)