### PR TITLE
Include header, type and per-field errors in invalid-packet log

### DIFF
--- a/src/NosCore.Networking/NetworkClient.cs
+++ b/src/NosCore.Networking/NetworkClient.cs
@@ -8,9 +8,11 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using NosCore.Networking.Encoding;
 using NosCore.Networking.Resource;
+using NosCore.Packets.Attributes;
 using NosCore.Packets.Interfaces;
 using NosCore.Shared.I18N;
 using Serilog;
@@ -125,7 +127,25 @@ namespace NosCore.Networking
             {
                 if (packet?.IsValid == false)
                 {
-                    _logger.Error(_logLanguage[LogLanguageKey.SENDING_INVALID_PACKET], packet.Header, packet.ValidationResult);
+                    var packetType = packet.GetType();
+                    var header = packet.Header
+                        ?? packetType.GetCustomAttribute<PacketHeaderAttribute>()?.Identification
+                        ?? "?";
+                    var errors = string.Join("; ", packet.ValidationResult.Select(v =>
+                    {
+                        var members = v.MemberNames.ToList();
+                        if (members.Count == 0)
+                        {
+                            return v.ErrorMessage ?? "validation failed";
+                        }
+                        var rendered = string.Join(",", members.Select(m =>
+                        {
+                            var value = packetType.GetProperty(m)?.GetValue(packet);
+                            return $"{m}={value ?? "null"}";
+                        }));
+                        return $"{rendered}: {v.ErrorMessage ?? "validation failed"}";
+                    }));
+                    _logger.Error(_logLanguage[LogLanguageKey.SENDING_INVALID_PACKET], header, packetType.FullName, errors);
                 }
                 LastPackets.Enqueue(packet);
             }

--- a/src/NosCore.Networking/NosCore.Networking.csproj
+++ b/src/NosCore.Networking/NosCore.Networking.csproj
@@ -12,7 +12,7 @@
 		<RepositoryUrl>https://github.com/NosCoreIO/NosCore.Networking.git</RepositoryUrl>
 		<PackageIconUrl></PackageIconUrl>
 		<PackageTags>nostale, noscore, nostale private server source, nostale emulator</PackageTags>
-		<Version>7.0.0</Version>
+		<Version>7.1.0</Version>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<Description>NosCore Networking</Description>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/NosCore.Networking/Resource/LocalizedResources.Designer.cs
+++ b/src/NosCore.Networking/Resource/LocalizedResources.Designer.cs
@@ -133,7 +133,7 @@ namespace NosCore.Networking.Resource {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Sending an invalid packet: {PacketHeader} {ValidationResult}.
+        ///   Looks up a localized string similar to Sending an invalid packet: header={PacketHeader} type={PacketType} errors=[{ValidationErrors}].
         /// </summary>
         public static string SENDING_INVALID_PACKET {
             get {

--- a/src/NosCore.Networking/Resource/LocalizedResources.fr.resx
+++ b/src/NosCore.Networking/Resource/LocalizedResources.fr.resx
@@ -136,7 +136,7 @@
     <value>Écoute du port</value>
   </data>
   <data name="SENDING_INVALID_PACKET" xml:space="preserve">
-    <value>Envoi d'un packet invalide: {PacketHeader} {ValidationResult}</value>
+    <value>Envoi d'un packet invalide: header={PacketHeader} type={PacketType} errors=[{ValidationErrors}]</value>
   </data>
   <data name="CORRUPTED_PACKET" xml:space="preserve">
     <value>Paquet corrompu: {0} - {1}</value>

--- a/src/NosCore.Networking/Resource/LocalizedResources.resx
+++ b/src/NosCore.Networking/Resource/LocalizedResources.resx
@@ -136,7 +136,7 @@
     <value>Listening Port {0}</value>
   </data>
   <data name="SENDING_INVALID_PACKET" xml:space="preserve">
-    <value>Sending an invalid packet: {PacketHeader} {ValidationResult}</value>
+    <value>Sending an invalid packet: header={PacketHeader} type={PacketType} errors=[{ValidationErrors}]</value>
   </data>
   <data name="ERROR_SESSIONID" xml:space="preserve">
     <value>Invalid session ID: {0}</value>


### PR DESCRIPTION
## Summary
- Log now resolves the header via `[PacketHeader]` attribute when `packet.Header` is null (outgoing packets don't set Header).
- Adds full type name and per-validation-error `Member=Value: ErrorMessage` lines so the broken packet can be located in trace captures.

Before: `Sending an invalid packet: null ["Invalid Enum value"]`
After:  `Sending an invalid packet: header=tc_info type=NosCore.Packets.ServerPackets.UI.TcInfoPacket errors=[Sex=99: Invalid Enum value]`

## Test plan
- [x] `dotnet build -c Release`
- [x] `dotnet test --filter TestCategory!=OPTIONAL-TEST`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for invalid packets to include detailed debugging information with packet type and expanded error context.

* **Chores**
  * Updated package version to 7.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->