### PR TITLE
Expose RemoteAddress on IChannel

### DIFF
--- a/src/NosCore.Networking/IChannel.cs
+++ b/src/NosCore.Networking/IChannel.cs
@@ -20,6 +20,12 @@ namespace NosCore.Networking
         string Id { get; }
 
         /// <summary>
+        /// Gets the remote peer's IP address as a string, or null if the
+        /// underlying session has no routable endpoint yet.
+        /// </summary>
+        string? RemoteAddress { get; }
+
+        /// <summary>
         /// Disconnects the channel asynchronously.
         /// </summary>
         /// <returns>A task representing the asynchronous disconnect operation.</returns>

--- a/src/NosCore.Networking/NetworkChannel.cs
+++ b/src/NosCore.Networking/NetworkChannel.cs
@@ -5,6 +5,7 @@
 // -----------------------------------
 
 using System;
+using System.Net;
 using System.Threading.Tasks;
 using SuperSocket.Connection;
 using SuperSocket.Server.Abstractions.Session;
@@ -31,6 +32,12 @@ namespace NosCore.Networking
         /// Gets the unique identifier for this channel.
         /// </summary>
         public string Id => _session.SessionID;
+
+        /// <summary>
+        /// Gets the remote peer's IP address as a string, or null if the
+        /// underlying session has no routable endpoint yet.
+        /// </summary>
+        public string? RemoteAddress => (_session.RemoteEndPoint as IPEndPoint)?.Address.ToString();
 
         /// <summary>
         /// Disconnects the channel asynchronously.

--- a/src/NosCore.Networking/NosCore.Networking.csproj
+++ b/src/NosCore.Networking/NosCore.Networking.csproj
@@ -12,7 +12,7 @@
 		<RepositoryUrl>https://github.com/NosCoreIO/NosCore.Networking.git</RepositoryUrl>
 		<PackageIconUrl></PackageIconUrl>
 		<PackageTags>nostale, noscore, nostale private server source, nostale emulator</PackageTags>
-		<Version>7.1.0</Version>
+		<Version>7.2.0</Version>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<Description>NosCore Networking</Description>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary
- Adds `RemoteAddress` to `IChannel` / `NetworkChannel` so hosts can read the peer IP of a session without reaching into SuperSocket internals.
- Bumps the package to `7.2.0`.

## Test plan
- [x] `dotnet build` green on `NosCore.Networking.sln`
- [ ] Downstream consumer (NosCore WebApi NosMall endpoint) verifies the new property returns the expected IP once the new version ships.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Network connections now expose the remote peer's IP address, allowing access to this information when the connection is established. The remote address returns null if the endpoint is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->