### PR TITLE
feat!: migrate NetworkClient from Serilog.ILogger to Microsoft.Extensions.Logging.ILogger

### DIFF
--- a/src/NosCore.Networking/NetworkClient.cs
+++ b/src/NosCore.Networking/NetworkClient.cs
@@ -10,12 +10,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using NosCore.Networking.Encoding;
 using NosCore.Networking.Resource;
 using NosCore.Packets.Attributes;
 using NosCore.Packets.Interfaces;
 using NosCore.Shared.I18N;
-using Serilog;
 
 namespace NosCore.Networking
 {
@@ -92,7 +92,7 @@ namespace NosCore.Networking
         /// <returns>A task representing the asynchronous disconnect operation.</returns>
         public async Task DisconnectAsync()
         {
-            _logger.Information(_logLanguage[LogLanguageKey.FORCED_DISCONNECTION], SessionId);
+            _logger.LogInformation(_logLanguage[LogLanguageKey.FORCED_DISCONNECTION], SessionId);
             NetworkClientRegistry.Unregister(this);
             if (_channel != null)
             {
@@ -145,7 +145,7 @@ namespace NosCore.Networking
                         }));
                         return $"{rendered}: {v.ErrorMessage ?? "validation failed"}";
                     }));
-                    _logger.Error(_logLanguage[LogLanguageKey.SENDING_INVALID_PACKET], header, packetType.FullName, errors);
+                    _logger.LogError(_logLanguage[LogLanguageKey.SENDING_INVALID_PACKET], header, packetType.FullName, errors);
                 }
                 LastPackets.Enqueue(packet);
             }
@@ -167,7 +167,7 @@ namespace NosCore.Networking
             }
             catch (Exception ex)
             {
-                _logger.Warning(ex, _logLanguage[LogLanguageKey.ENCODE_ERROR], SessionId);
+                _logger.LogWarning(ex, _logLanguage[LogLanguageKey.ENCODE_ERROR], SessionId);
             }
         }
     }

--- a/src/NosCore.Networking/NosCore.Networking.csproj
+++ b/src/NosCore.Networking/NosCore.Networking.csproj
@@ -12,7 +12,7 @@
 		<RepositoryUrl>https://github.com/NosCoreIO/NosCore.Networking.git</RepositoryUrl>
 		<PackageIconUrl></PackageIconUrl>
 		<PackageTags>nostale, noscore, nostale private server source, nostale emulator</PackageTags>
-		<Version>7.2.0</Version>
+		<Version>8.0.0</Version>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<Description>NosCore Networking</Description>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary
- `NetworkClient` ctor now takes `Microsoft.Extensions.Logging.ILogger` (non-generic) instead of `Serilog.ILogger`. All other files in this repo were already on MEL `ILogger<T>`; only `NetworkClient` remained.
- Kept non-generic because `NetworkClient` is a base class that derived types (e.g. `ClientSession`) inherit from; the generic `ILogger<Derived>` implicitly converts to non-generic `ILogger`.
- Bumps version to **8.0.0** (breaking change).

## Test plan
- [x] `dotnet test` green.

Refs NosCoreIO/NosCore#1607.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * NosCore.Networking package version bumped to 8.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->