### PR TITLE
chore: bump all NuGet packages to latest and fix CheckLanguageUsage CWD

### DIFF
--- a/src/NosCore.Networking/NosCore.Networking.csproj
+++ b/src/NosCore.Networking/NosCore.Networking.csproj
@@ -27,11 +27,11 @@
 	<ItemGroup>
 		<PackageReference Include="SuperSocket.Server" Version="2.1.0" />
 		<PackageReference Include="SuperSocket.ProtoBase" Version="2.1.0" />
-		<PackageReference Include="NodaTime" Version="3.3.1" />
-		<PackageReference Include="NosCore.Packets" Version="15.0.0" />
-		<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.17.0" />
-		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
-		<PackageReference Include="Serilog" Version="4.3.1" />
+		<PackageReference Include="NodaTime" Version="3.3.3" />
+		<PackageReference Include="NosCore.Packets" Version="20.0.3" />
+		<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.22.0" />
+		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.22.0" />
+		<PackageReference Include="Serilog" Version="4.4.0" />
 		<PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
 	</ItemGroup>
 

--- a/test/NosCore.Networking.Tests/LogLanguageTests.cs
+++ b/test/NosCore.Networking.Tests/LogLanguageTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
@@ -18,6 +19,9 @@ namespace NosCore.Networking.Tests
 
         public LogLanguageTests()
         {
+            // I18NTestHelpers resolves the repo root relative to the current directory,
+            // assuming the legacy test-runner behavior of running from the project folder.
+            Environment.CurrentDirectory = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", ".."));
             var factory =
                 new ResourceManagerStringLocalizerFactory(Options.Create(new LocalizationOptions()),
                     new LoggerFactory());

--- a/test/NosCore.Networking.Tests/NosCore.Networking.Tests.csproj
+++ b/test/NosCore.Networking.Tests/NosCore.Networking.Tests.csproj
@@ -20,18 +20,18 @@
 
 	<ItemGroup>
 		<PackageReference Include="ApprovalTests" Version="7.0.0" />
-		<PackageReference Include="coverlet.collector" Version="10.0.0">
+		<PackageReference Include="coverlet.collector" Version="10.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-		<PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-		<PackageReference Include="NodaTime.Testing" Version="3.3.1" />
-		<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.17.0" />
-		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="4.3.3" />
+		<PackageReference Include="MSTest.TestFramework" Version="4.3.3" />
+		<PackageReference Include="NodaTime.Testing" Version="3.3.3" />
+		<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.22.0" />
+		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.22.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
- Bump NosCore.Packets 15.0.0 -> 20.0.3, NodaTime/NodaTime.Testing 3.3.1 -> 3.3.3, Serilog 4.3.1 -> 4.4.0
- Bump Microsoft.IdentityModel.JsonWebTokens and System.IdentityModel.Tokens.Jwt 8.17.0 -> 8.22.0
- Bump MSTest 4.2.1 -> 4.3.3, Microsoft.NET.Test.Sdk 18.4.0 -> 18.8.1, coverlet.collector 10.0.0 -> 10.0.1
- Fix LogLanguageTests: set CurrentDirectory to the project folder so I18NTestHelpers resolves the repo root regardless of runner CWD

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated underlying components to improve compatibility, stability, and security.
  * Refreshed supporting validation tools to keep quality checks current.

* **Bug Fixes**
  * Improved localization test setup so resources are consistently found regardless of the execution directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->